### PR TITLE
Dockerfile: clone hackworks patched zcashd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,48 @@
 FROM debian:latest
+# Run 'docker build .' from github clone
+# docker run -p80:3001 -v $(pwd)/dot-zcash:/home/zcashd/.zcash
 
-RUN apt-get update
+RUN apt-get update \
+    && apt-get install -y gnupg2 wget libzmq3-dev git \
+# zcash build (see RTD User Guide):
+    && apt-get -qqy install \
+        build-essential pkg-config libc6-dev m4 g++-multilib \
+        autoconf libtool ncurses-dev unzip git python python-zmq \
+        zlib1g-dev wget curl bsdmainutils automake \
+    \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt-get install -y nodejs
 
-RUN apt-get install -y curl
-RUN apt-get install -y gnupg2
-RUN apt-get install -y wget
-RUN apt-get install -y libzmq3-dev
-RUN apt-get install -y git
-RUN apt-get install -y build-essential
-
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get install -y nodejs
-
-RUN wget -qO - https://apt.z.cash/zcash.asc | apt-key add -
-RUN echo "deb [arch=amd64] https://apt.z.cash/ jessie main" | tee /etc/apt/sources.list.d/zcash.list
-RUN apt-get update && apt-get install -y zcash
-
-RUN useradd -m zcashd 
-
-RUN mkdir -p /home/zcashd/.npm-global ; \
-    mkdir -p /home/zcashd/.zcash/ ; \ 
-    mkdir -p /home/zcashd/.zcash-params/ ; \
-    chown -R zcashd /home/zcashd
+RUN useradd -m zcashd \
+    && mkdir -p /home/zcashd/.npm-global \
+    && mkdir -p /home/zcashd/.zcash/ \ 
+    && mkdir -p /home/zcashd/.zcash-params/ \
+    && chown -R zcashd /home/zcashd \
+    && true
 ENV PATH=/home/zcashd/.npm-global/bin:$PATH
 ENV NPM_CONFIG_PREFIX=/home/zcashd/.npm-global
 
-ENV x x 
-COPY --chown=zcashd:zcashd ./zcash.conf /home/zcashd/.zcash/zcash.conf
-
 USER zcashd 
+WORKDIR /home/zcashd/
 
+RUN git clone https://github.com/zcash-hackworks/zcash-patched-for-explorer.git
+WORKDIR /home/zcashd/zcash-patched-for-explorer
+RUN git checkout v2.0.2-insight-explorer
+
+# keep jobs low to minimize chances of running out of memory
+RUN zcutil/build.sh -j2
+RUN zcutil/fetch-params.sh
+
+WORKDIR /home/zcashd/
 RUN npm install -g npm@latest
 RUN npm -g install zcash-hackworks/bitcore-node-zcash
 
-WORKDIR /home/zcashd/
 RUN bitcore-node create zc
 COPY --chown=zcashd:zcashd ./bitcore-node.json /home/zcashd/zc/
 
 WORKDIR /home/zcashd/zc/
 RUN bitcore-node install zcash-hackworks/insight-api-zcash zcash-hackworks/insight-ui-zcash
 
-RUN zcash-fetch-params --testnet
-
 RUN sed -i 's/testnet = false/testnet = true/g' /home/zcashd/zc/node_modules/insight-ui-zcash/public/src/js/app.js
 
-ENTRYPOINT ["/home/zcashd/zc/node_modules/bitcore-node-zcash/bin/bitcore-node", "start"]
+CMD ["/home/zcashd/zc/node_modules/bitcore-node-zcash/bin/bitcore-node", "start"]

--- a/bitcore-node.json
+++ b/bitcore-node.json
@@ -9,7 +9,7 @@
     "bitcoind": {
       "spawn": {
         "datadir": "/home/zcashd/.zcash",
-        "exec": "/usr/bin/zcashd"
+        "exec": "/home/zcashd/zcash-patched-for-explorer/src/zcashd"
       }
     },
     "insight-api-zcash": {

--- a/dot-zcash/zcash.conf
+++ b/dot-zcash/zcash.conf
@@ -1,0 +1,15 @@
+testnet=1
+server=1
+whitelist=127.0.0.1
+zmqpubrawtx=tcp://127.0.0.1:9994
+zmqpubhashblock=tcp://127.0.0.1:9994
+addnode=testnet.z.cash
+rpcallowip=127.0.0.1
+rpcuser=bitcoin
+rpcpassword=local321
+#showmetrics=0
+txindex=1
+addressindex=1
+timestampindex=1
+spentindex=1
+uacomment=bitcore


### PR DESCRIPTION
Standard zcashd doesn't work for insight, must use the insight-patched version